### PR TITLE
Add initial set of collectors

### DIFF
--- a/src/main/java/com/aws/emr/profiler/core/MapReduceProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/MapReduceProfiler.java
@@ -16,6 +16,9 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class MapReduceProfiler implements Profiler {
+    @Override
+    public void profile() {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/com/aws/emr/profiler/core/NotImplementedException.java
+++ b/src/main/java/com/aws/emr/profiler/core/NotImplementedException.java
@@ -16,6 +16,5 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class NotImplementedException extends RuntimeException {
 }

--- a/src/main/java/com/aws/emr/profiler/core/PigProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/PigProfiler.java
@@ -16,6 +16,9 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class PigProfiler implements Profiler {
+    @Override
+    public void profile() {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/com/aws/emr/profiler/core/PrestoProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/PrestoProfiler.java
@@ -16,6 +16,9 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class PrestoProfiler implements Profiler {
+    @Override
+    public void profile() {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/com/aws/emr/profiler/core/SparkProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/SparkProfiler.java
@@ -16,6 +16,9 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class SparkProfiler implements Profiler {
+    @Override
+    public void profile() {
+        throw new NotImplementedException();
+    }
 }

--- a/src/main/java/com/aws/emr/profiler/core/YARNProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/YARNProfiler.java
@@ -16,6 +16,9 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+public class YARNProfiler implements Profiler {
+    @Override
+    public void profile() {
+        throw new NotImplementedException();
+    }
 }

--- a/src/test/java/com/aws/emr/profiler/core/MapReduceProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/MapReduceProfilerTest.java
@@ -16,6 +16,12 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+import org.testng.annotations.Test;
+
+public class MapReduceProfilerTest {
+    @Test(expectedExceptions = NotImplementedException.class)
+    public void firstTest() {
+        Profiler p = new MapReduceProfiler();
+        p.profile();
+    }
 }

--- a/src/test/java/com/aws/emr/profiler/core/PigProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/PigProfilerTest.java
@@ -16,6 +16,12 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+import org.testng.annotations.Test;
+
+public class PigProfilerTest {
+    @Test(expectedExceptions = NotImplementedException.class)
+    public void firstTest() {
+        Profiler p = new PigProfiler();
+        p.profile();
+    }
 }

--- a/src/test/java/com/aws/emr/profiler/core/PrestoProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/PrestoProfilerTest.java
@@ -13,15 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.aws.emr.profiler.core;
 
 import org.testng.annotations.Test;
 
-public class ProfilerTest {
-
-    @Test(expectedExceptions = RuntimeException.class)
+public class PrestoProfilerTest {
+    @Test(expectedExceptions = NotImplementedException.class)
     public void firstTest() {
-        Profiler p = new Profiler();
+        Profiler p = new PrestoProfiler();
         p.profile();
     }
 }

--- a/src/test/java/com/aws/emr/profiler/core/SparkProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/SparkProfilerTest.java
@@ -16,6 +16,12 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+import org.testng.annotations.Test;
+
+public class SparkProfilerTest {
+    @Test(expectedExceptions = NotImplementedException.class)
+    public void firstTest() {
+        Profiler p = new SparkProfiler();
+        p.profile();
+    }
 }

--- a/src/test/java/com/aws/emr/profiler/core/YARNProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/YARNProfilerTest.java
@@ -16,6 +16,12 @@
 
 package com.aws.emr.profiler.core;
 
-public interface Profiler {
-    void profile();
+import org.testng.annotations.Test;
+
+public class YARNProfilerTest {
+    @Test(expectedExceptions = NotImplementedException.class)
+    public void firstTest() {
+        Profiler p = new YARNProfiler();
+        p.profile();
+    }
 }


### PR DESCRIPTION
This change adds the initial set of profiler classes
and changes the profiler class to an interface.

The profiler will support collecting from all of the different
application types that run on EMR. The interface is created
to make it simple and easy to add new profilers when
new application types are supported on EMR.

Pull requests are always welcome.

*Issue #, if available:*  10

*Description of changes:* Default changes that do nothing but have unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
