### PR TITLE
Add initial Spark profiler and persistence of profiling data to S3.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .DS_STORE
 .idea
 *.iml
+*.log
 target
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -37,21 +37,6 @@
             <version>3.8.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <version>2.6.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
-            <version>2.6.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.16</version>
-        </dependency>
-        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>1.11.234</version>
@@ -60,6 +45,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <version>1.2.17</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
@@ -76,6 +66,11 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/resources</directory>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -85,6 +80,47 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/resources</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/resources</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>com.aws.emr.profiler.cli.Main</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <version>2.13.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>3.8.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/aws/emr/profiler/cli/Config.java
+++ b/src/main/java/com/aws/emr/profiler/cli/Config.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.log4j.Logger;
+
+@Data
+@Builder
+public class Config {
+    private static Logger LOG = Logger.getLogger(Config.class);
+
+    @Getter
+    @Setter
+    private String s3Bucket;
+
+    @Getter
+    @Setter
+    private List<String> enabledProfilers;
+
+    public static Optional<Config> parseConfig(String configPath)  {
+        try {
+            File configFile = new File(configPath);
+            Gson serializer = new GsonBuilder().create();
+            return Optional.of(tryParseConfig(configFile, serializer));
+        } catch (Exception ex) {
+            LOG.error(ex);
+            return Optional.empty();
+        }
+    }
+
+    private static Config tryParseConfig(File configFile, Gson serializer) throws Exception {
+        try (   FileInputStream inputStream = new FileInputStream(configFile);
+                InputStreamReader inputStreamReader = new InputStreamReader(inputStream, Charset.defaultCharset());
+                JsonReader reader = new JsonReader(inputStreamReader)
+        ) {
+            return serializer.fromJson(reader, Config.class);
+        }
+    }
+}

--- a/src/main/java/com/aws/emr/profiler/cli/Config.java
+++ b/src/main/java/com/aws/emr/profiler/cli/Config.java
@@ -16,6 +16,13 @@
 
 package com.aws.emr.profiler.cli;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.stream.JsonReader;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.log4j.Log4j;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
@@ -23,26 +30,11 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Optional;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.stream.JsonReader;
-import lombok.Builder;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import org.apache.log4j.Logger;
-
-@Data
 @Builder
+@Data
+@Log4j
 public class Config {
-    private static Logger LOG = Logger.getLogger(Config.class);
-
-    @Getter
-    @Setter
     private String s3Bucket;
-
-    @Getter
-    @Setter
     private List<String> enabledProfilers;
 
     public static Optional<Config> parseConfig(String configPath)  {
@@ -51,7 +43,7 @@ public class Config {
             Gson serializer = new GsonBuilder().create();
             return Optional.of(tryParseConfig(configFile, serializer));
         } catch (Exception ex) {
-            LOG.error(ex);
+            log.error(ex);
             return Optional.empty();
         }
     }

--- a/src/main/java/com/aws/emr/profiler/cli/InvalidConfigFileException.java
+++ b/src/main/java/com/aws/emr/profiler/cli/InvalidConfigFileException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+public class InvalidConfigFileException extends Exception {
+}

--- a/src/main/java/com/aws/emr/profiler/cli/Main.java
+++ b/src/main/java/com/aws/emr/profiler/cli/Main.java
@@ -17,22 +17,22 @@
 package com.aws.emr.profiler.cli;
 
 import com.aws.emr.profiler.core.Profiler;
-import org.apache.log4j.Logger;
+import lombok.extern.log4j.Log4j;
 
 import java.util.List;
 
+@Log4j
 public class Main {
     private static String DEFAULT_CONFIG_PATH = System.getProperty("user.home") + "/.emr-profiler/config.json";
-    private static Logger LOG = Logger.getLogger(Main.class);
 
     public static void main(String[] args) throws Exception {
-        LOG.info("Parsing config");
-        Config c = Config.parseConfig(DEFAULT_CONFIG_PATH).orElseThrow(InvalidConfigFileException::new);
+        log.info("Parsing config");
+        Config config = Config.parseConfig(DEFAULT_CONFIG_PATH).orElseThrow(InvalidConfigFileException::new);
 
-        LOG.info("Creating profilers");
-        List<Profiler> profilers = ProfilerFactory.createProfilers(c);
+        log.info("Creating profilers");
+        List<Profiler> profilers = ProfilerFactory.createProfilers(config);
 
-        LOG.info("Running profilers");
+        log.info("Running profilers");
         profilers.parallelStream().forEach(p -> p.profile());
     }
 }

--- a/src/main/java/com/aws/emr/profiler/cli/Main.java
+++ b/src/main/java/com/aws/emr/profiler/cli/Main.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+import com.aws.emr.profiler.core.Profiler;
+import org.apache.log4j.Logger;
+
+import java.util.List;
+
+public class Main {
+    private static String DEFAULT_CONFIG_PATH = System.getProperty("user.home") + "/.emr-profiler/config.json";
+    private static Logger LOG = Logger.getLogger(Main.class);
+
+    public static void main(String[] args) throws Exception {
+        LOG.info("Parsing config");
+        Config c = Config.parseConfig(DEFAULT_CONFIG_PATH).orElseThrow(InvalidConfigFileException::new);
+
+        LOG.info("Creating profilers");
+        List<Profiler> profilers = ProfilerFactory.createProfilers(c);
+
+        LOG.info("Running profilers");
+        profilers.parallelStream().forEach(p -> p.profile());
+    }
+}

--- a/src/main/java/com/aws/emr/profiler/cli/ProfilerFactory.java
+++ b/src/main/java/com/aws/emr/profiler/cli/ProfilerFactory.java
@@ -17,25 +17,30 @@
 package com.aws.emr.profiler.cli;
 
 import com.aws.emr.profiler.core.Profiler;
+import lombok.extern.log4j.Log4j;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Log4j
 public class ProfilerFactory {
-    private static String DEFAULT_PROFILER_CLASS ="com.aws.emr.profiler.core.";
+    private static String DEFAULT_PROFILER_PACKAGE ="com.aws.emr.profiler.core.";
 
-    public static List<Profiler> createProfilers(Config c) throws Exception {
-        return c.getEnabledProfilers().parallelStream().map(p -> createProfiler(c, p)).filter(p -> p.isPresent())
-                .map(p -> p.get()).collect(Collectors.toList());
+    public static List<Profiler> createProfilers(Config config) throws Exception {
+        return config.getEnabledProfilers().parallelStream()
+                .map(profiler -> createProfiler(config, profiler))
+                .filter(profiler -> profiler.isPresent())
+                .map(profiler -> profiler.get()).collect(Collectors.toList());
     }
 
-    private static Optional<Profiler> createProfiler(Config c, String profilerClassName) {
+    private static Optional<Profiler> createProfiler(Config config, String profilerClassName) {
         try {
-            Class profilerClass = Class.forName(DEFAULT_PROFILER_CLASS + profilerClassName);
-            Profiler p =  (Profiler) profilerClass.getConstructor(Config.class).newInstance(c);
-            return Optional.of(p);
+            Class profilerClass = Class.forName(DEFAULT_PROFILER_PACKAGE + profilerClassName);
+            Profiler profiler =  (Profiler) profilerClass.getConstructor(Config.class).newInstance(config);
+            return Optional.of(profiler);
         } catch (Exception ex) {
+            log.error(ex);
             return Optional.empty();
         }
     }

--- a/src/main/java/com/aws/emr/profiler/cli/ProfilerFactory.java
+++ b/src/main/java/com/aws/emr/profiler/cli/ProfilerFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+import com.aws.emr.profiler.core.Profiler;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public class ProfilerFactory {
+    private static String DEFAULT_PROFILER_CLASS ="com.aws.emr.profiler.core.";
+
+    public static List<Profiler> createProfilers(Config c) throws Exception {
+        return c.getEnabledProfilers().parallelStream().map(p -> createProfiler(c, p)).filter(p -> p.isPresent())
+                .map(p -> p.get()).collect(Collectors.toList());
+    }
+
+    private static Optional<Profiler> createProfiler(Config c, String profilerClassName) {
+        try {
+            Class profilerClass = Class.forName(DEFAULT_PROFILER_CLASS + profilerClassName);
+            Profiler p =  (Profiler) profilerClass.getConstructor(Config.class).newInstance(c);
+            return Optional.of(p);
+        } catch (Exception ex) {
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/aws/emr/profiler/core/SparkProfiler.java
+++ b/src/main/java/com/aws/emr/profiler/core/SparkProfiler.java
@@ -28,23 +28,23 @@ public class SparkProfiler implements Profiler {
 
     private static String FILE_NAME_FORMAT = "emr-profiler-spark-metrics-%tQ";
 
-    private MetricsCollector sparkMetricsCollector;
-    private Persister s3MetricsPersister;
+    private MetricsCollector metricsCollector;
+    private Persister metricsPersister;
 
     public SparkProfiler(Config config) {
-        this.sparkMetricsCollector = new SparkMetricsCollector();
-        this.s3MetricsPersister = new S3Persister(config.getS3Bucket());
+        this.metricsCollector = new SparkMetricsCollector();
+        this.metricsPersister = new S3Persister(config.getS3Bucket());
     }
 
-    public SparkProfiler(MetricsCollector sparkMetricsCollector, Persister s3MetricsPersister) {
-        this.sparkMetricsCollector = sparkMetricsCollector;
-        this.s3MetricsPersister = s3MetricsPersister;
+    public SparkProfiler(MetricsCollector metricsCollector, Persister metricsPersister) {
+        this.metricsCollector = metricsCollector;
+        this.metricsPersister = metricsPersister;
     }
 
     @Override
     public void profile() {
-        String metrics = sparkMetricsCollector.getSerializedMetrics();
+        String metrics = metricsCollector.getSerializedMetrics();
         String fileName = String.format(FILE_NAME_FORMAT, Instant.now().toEpochMilli());
-        s3MetricsPersister.saveMetrics(fileName, metrics);
+        metricsPersister.saveMetrics(fileName, metrics);
     }
 }

--- a/src/main/java/com/aws/emr/profiler/core/metricscollector/MetricsCollector.java
+++ b/src/main/java/com/aws/emr/profiler/core/metricscollector/MetricsCollector.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.metricscollector;
+
+public interface MetricsCollector {
+    String getSerializedMetrics();
+}

--- a/src/main/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollector.java
+++ b/src/main/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollector.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.metricscollector;
+
+import com.aws.emr.profiler.core.requestprocessor.HTTPRequestProcessor;
+import com.google.gson.Gson;
+
+public class SparkMetricsCollector implements MetricsCollector {
+
+    private static final String SPARK_HISTORY_SERVER = "http://%s:18080/api/v1/applications";
+
+    private HTTPRequestProcessor httpRequestProcessor;
+
+    public SparkMetricsCollector() {
+        this.httpRequestProcessor = new HTTPRequestProcessor();
+    }
+
+    public SparkMetricsCollector(HTTPRequestProcessor httpRequestProcessor) {
+        this.httpRequestProcessor = httpRequestProcessor;
+    }
+
+    @Override
+    public String getSerializedMetrics() {
+        return httpRequestProcessor.makeHttpGetRequest(getSparkRESTAPIEndpoint());
+        // todo: add metrics for job, tasks, stages, executors, events, etc.
+    }
+
+    private String getSparkRESTAPIEndpoint() {
+        return String.format(SPARK_HISTORY_SERVER, httpRequestProcessor.getLocalHostName());
+    }
+}

--- a/src/main/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollector.java
+++ b/src/main/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollector.java
@@ -17,7 +17,6 @@
 package com.aws.emr.profiler.core.metricscollector;
 
 import com.aws.emr.profiler.core.requestprocessor.HTTPRequestProcessor;
-import com.google.gson.Gson;
 
 public class SparkMetricsCollector implements MetricsCollector {
 

--- a/src/main/java/com/aws/emr/profiler/core/persister/Persister.java
+++ b/src/main/java/com/aws/emr/profiler/core/persister/Persister.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.persister;
+
+public interface Persister {
+    void saveMetrics(String fileName, String metrics);
+}

--- a/src/main/java/com/aws/emr/profiler/core/persister/S3Persister.java
+++ b/src/main/java/com/aws/emr/profiler/core/persister/S3Persister.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.persister;
+
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.Optional;
+
+public class S3Persister implements Persister {
+    private static Optional<TransferManager> transferManager;
+    private String s3Bucket;
+
+    public S3Persister(String s3Bucket) {
+        this.s3Bucket = s3Bucket;
+        this.transferManager = Optional.of(TransferManagerBuilder.defaultTransferManager());
+    }
+
+    public S3Persister(TransferManager transferManager, String s3Bucket) {
+        this.transferManager = Optional.of(transferManager);
+        this.s3Bucket = s3Bucket;
+    }
+
+    @Override
+    public void saveMetrics(String fileName, String metrics) {
+        try {
+            prepareTransferManager();
+            File file = new File(fileName);
+            tryWriteToFile(metrics, file);
+            tryUploadFile(file.getName(), file);
+        } finally {
+            FileUtils.deleteQuietly(new File(fileName));
+            shutdownTransferManager();
+        }
+    }
+
+    private void prepareTransferManager() {
+        if (!transferManager.isPresent()) {
+            this.transferManager = Optional.of(TransferManagerBuilder.defaultTransferManager());
+        }
+    }
+
+    private void shutdownTransferManager() {
+        transferManager.get().shutdownNow();
+        transferManager = Optional.empty();
+    }
+
+    private void tryWriteToFile(String serializedData, File file) {
+        try {
+            Files.write(serializedData, file, Charset.forName(Charsets.UTF_8.toString()));
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private void tryUploadFile(String fileName, File file) {
+        try {
+            transferManager.get().upload(s3Bucket, fileName, file).waitForCompletion();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/main/java/com/aws/emr/profiler/core/requestprocessor/HTTPRequestProcessor.java
+++ b/src/main/java/com/aws/emr/profiler/core/requestprocessor/HTTPRequestProcessor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.requestprocessor;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class HTTPRequestProcessor {
+    private static OkHttpClient httpClient = new OkHttpClient();
+    private static String INSTANCE_METADATA_ENDPOINT = "169.254.169.254";
+    private static String INSTANCE_METADATA_URI = "http://%s/latest/meta-data/local-hostname";
+
+    public HTTPRequestProcessor() {
+        this.INSTANCE_METADATA_URI = String.format(INSTANCE_METADATA_URI, INSTANCE_METADATA_ENDPOINT);
+    }
+
+    public HTTPRequestProcessor(String host) {
+        this.INSTANCE_METADATA_URI = String.format(INSTANCE_METADATA_URI, host);
+    }
+
+    public HTTPRequestProcessor(OkHttpClient httpClient) {
+        this.httpClient = httpClient;
+        this.INSTANCE_METADATA_URI = String.format(INSTANCE_METADATA_URI, INSTANCE_METADATA_ENDPOINT);
+    }
+
+    public String makeHttpGetRequest(String url) {
+        Request request = new Request.Builder().get().url(url).build();
+        Response response = tryMakeRequest(request);
+        return tryGetResponseBody(response);
+    }
+
+    private Response tryMakeRequest(Request request) {
+        try {
+            return httpClient.newCall(request).execute();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private String tryGetResponseBody(Response response) {
+        try {
+            return response.body().string();
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public String getLocalHostName() {
+        Request request = new Request.Builder().get().url(INSTANCE_METADATA_URI).build();
+        Response response = tryMakeRequest(request);
+        return tryGetResponseBody(response);
+    }
+}

--- a/src/resources/config.json
+++ b/src/resources/config.json
@@ -1,0 +1,4 @@
+{
+  "s3Bucket": "workload-metrics",
+  "enabledProfilers": ["SparkProfiler"]
+}

--- a/src/resources/log4j.properties
+++ b/src/resources/log4j.properties
@@ -1,0 +1,13 @@
+log4j.rootLogger=INFO, stdout, file
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=EMR-Workload-Profiler: %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=emr-workload-profiler.log
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d [%t] %-5p (%F:%L) - %m%n
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=5

--- a/src/test/java/com/aws/emr/profiler/cli/ConfigTest.java
+++ b/src/test/java/com/aws/emr/profiler/cli/ConfigTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class ConfigTest {
+    @Test
+    public void defaultConfigTest() {
+        String s3BucketName = "foo";
+        Config c = new Config(s3BucketName, new ArrayList<>());
+        assertEquals(c.getS3Bucket(), s3BucketName);
+        assertEquals(c.getEnabledProfilers().size(), 0);
+    }
+
+    @Test
+    public void configWithProfilerEnabledTest() {
+        String s3BucketName = "bar";
+        String profilerClassName = "SPARK";
+        List<String> profilerList = new ArrayList<>();
+        profilerList.add(profilerClassName);
+
+
+        Config c = new Config(s3BucketName, profilerList);
+
+        assertEquals(c.getS3Bucket(), s3BucketName);
+        assertEquals(c.getEnabledProfilers().size(), 1);
+        assertEquals(c.getEnabledProfilers().get(0), profilerClassName);
+    }
+
+    @Test
+    public void configUpdateTest() {
+        String s3BucketName = "bar";
+        String profilerClassName = "SPARK";
+        List<String> profilerList = new ArrayList<>();
+        profilerList.add(profilerClassName);
+
+
+        Config c = new Config("foo", profilerList);
+        c.setS3Bucket(s3BucketName);
+        c.setEnabledProfilers(new ArrayList<>());
+
+        assertEquals(c.getS3Bucket(), s3BucketName);
+        assertEquals(c.getEnabledProfilers().size(), 0);
+    }
+
+    @Test
+    public void parseConfigTest() throws Exception {
+        File file = new File("src/resources/config.json");
+        Config c = Config.parseConfig(file.getAbsolutePath()).get();
+        assertEquals(c.getS3Bucket(), "workload-metrics");
+        assertEquals(c.getEnabledProfilers().size(), 1);
+    }
+
+    @Test
+    public void parseConfigInvalidTest() throws Exception {
+        File file = new File("foo.json");
+        Optional<Config> c = Config.parseConfig(file.getAbsolutePath());
+        assertFalse(c.isPresent());
+    }
+}

--- a/src/test/java/com/aws/emr/profiler/cli/ProfilerFactoryTest.java
+++ b/src/test/java/com/aws/emr/profiler/cli/ProfilerFactoryTest.java
@@ -16,12 +16,11 @@
 
 package com.aws.emr.profiler.cli;
 
-import java.util.List;
-
 import com.aws.emr.profiler.core.Profiler;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 

--- a/src/test/java/com/aws/emr/profiler/cli/ProfilerFactoryTest.java
+++ b/src/test/java/com/aws/emr/profiler/cli/ProfilerFactoryTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.cli;
+
+import java.util.List;
+
+import com.aws.emr.profiler.core.Profiler;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+
+import static org.testng.Assert.assertEquals;
+
+public class ProfilerFactoryTest {
+    @Test
+    public void invalidProfilerTest() throws Exception {
+        List<String> profilerClassNames = new ArrayList<>();
+        profilerClassNames.add("FOOO");
+        Config c = new Config("test", profilerClassNames);
+        List<Profiler> profilers = ProfilerFactory.createProfilers(c);
+        assertEquals(profilers.size(), 0);
+    }
+
+    @Test
+    public void sparkEnabledTest() throws Exception {
+        List<String> profilerClassNames = new ArrayList<>();
+        profilerClassNames.add("SparkProfiler");
+        Config c = new Config("test", profilerClassNames);
+        List<Profiler> profilers = ProfilerFactory.createProfilers(c);
+        assertEquals(profilers.size(), 1);
+    }
+
+}

--- a/src/test/java/com/aws/emr/profiler/core/SparkProfilerTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/SparkProfilerTest.java
@@ -16,12 +16,41 @@
 
 package com.aws.emr.profiler.core;
 
+import com.aws.emr.profiler.core.metricscollector.MetricsCollector;
+import com.aws.emr.profiler.core.metricscollector.SparkMetricsCollector;
+import com.aws.emr.profiler.core.persister.Persister;
+import com.aws.emr.profiler.core.persister.S3Persister;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 public class SparkProfilerTest {
-    @Test(expectedExceptions = NotImplementedException.class)
-    public void firstTest() {
-        Profiler p = new SparkProfiler();
-        p.profile();
+
+    private MetricsCollector sparkMetricsCollector;
+    private Persister s3Persister;
+    private Profiler sparkProfiler;
+
+    @BeforeMethod
+    public void setUp() {
+        s3Persister = mock(S3Persister.class);
+        sparkMetricsCollector = mock(SparkMetricsCollector.class);
+        sparkProfiler = new SparkProfiler(sparkMetricsCollector, s3Persister);
+    }
+
+    @Test
+    public void collectMetricsValid() {
+        when(sparkMetricsCollector.getSerializedMetrics()).thenReturn(SparkTestData.serializedSparkApplicationData);
+        doNothing().when(s3Persister).saveMetrics(any(), any());
+
+        sparkProfiler.profile();
+
+        verify(sparkMetricsCollector, times(1)).getSerializedMetrics();
+        verify(s3Persister, times(1)).saveMetrics(any(), any());
     }
 }

--- a/src/test/java/com/aws/emr/profiler/core/SparkTestData.java
+++ b/src/test/java/com/aws/emr/profiler/core/SparkTestData.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.aws.emr.profiler.core;
 
 public class SparkTestData {

--- a/src/test/java/com/aws/emr/profiler/core/SparkTestData.java
+++ b/src/test/java/com/aws/emr/profiler/core/SparkTestData.java
@@ -1,0 +1,21 @@
+package com.aws.emr.profiler.core;
+
+public class SparkTestData {
+    public final static String serializedSparkApplicationData =
+            "{\n" +
+                    "  \"id\" : \"application_1476167072801_0002\",\n" +
+                    "  \"name\" : \"Spark Pi\",\n" +
+                    "  \"attempts\" : [ {\n" +
+                    "    \"attemptId\" : \"1\",\n" +
+                    "    \"startTime\" : \"2016-10-11T06:35:26.219GMT\",\n" +
+                    "    \"endTime\" : \"2016-10-11T06:35:37.960GMT\",\n" +
+                    "    \"lastUpdated\" : \"2016-10-11T06:35:38.020GMT\",\n" +
+                    "    \"duration\" : 11741,\n" +
+                    "    \"sparkUser\" : \"hadoop\",\n" +
+                    "    \"completed\" : true,\n" +
+                    "    \"endTimeEpoch\" : 1476167737960,\n" +
+                    "    \"startTimeEpoch\" : 1476167726219,\n" +
+                    "    \"lastUpdatedEpoch\" : 1476167738020\n" +
+                    "  } ]\n" +
+                    "}";
+}

--- a/src/test/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollectorTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollectorTest.java
@@ -51,7 +51,3 @@ public class SparkMetricsCollectorTest {
         collector.getSerializedMetrics();
     }
 }
-
-
-
-

--- a/src/test/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollectorTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/metricscollector/SparkMetricsCollectorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.metricscollector;
+
+import com.aws.emr.profiler.core.SparkTestData;
+import com.aws.emr.profiler.core.requestprocessor.HTTPRequestProcessor;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class SparkMetricsCollectorTest {
+
+    private HTTPRequestProcessor mockHTTPRequestProcessor;
+
+    @BeforeMethod
+    public void setUp() {
+        mockHTTPRequestProcessor = mock(HTTPRequestProcessor.class);
+    }
+
+    @Test
+    public void collectMetricsValid() {
+        MetricsCollector collector = new SparkMetricsCollector(mockHTTPRequestProcessor);
+        when(mockHTTPRequestProcessor
+                .makeHttpGetRequest(anyString())).thenReturn(SparkTestData.serializedSparkApplicationData);
+        String result = collector.getSerializedMetrics();
+        assertEquals(result, SparkTestData.serializedSparkApplicationData);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void collectMetricsInvalid() {
+        MetricsCollector collector = new SparkMetricsCollector(mockHTTPRequestProcessor);
+        when(mockHTTPRequestProcessor.makeHttpGetRequest(anyString())).thenThrow(RuntimeException.class);
+        collector.getSerializedMetrics();
+    }
+}
+
+
+
+

--- a/src/test/java/com/aws/emr/profiler/core/persister/S3PersisterTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/persister/S3PersisterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.persister;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.transfer.TransferManager;
+import com.amazonaws.services.s3.transfer.Upload;
+import com.amazonaws.services.s3.transfer.model.UploadResult;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+
+public class S3PersisterTest {
+
+    private TransferManager transferManager;
+
+    @BeforeMethod
+    public void setUp() {
+        transferManager = mock(TransferManager.class);
+    }
+
+    @Test
+    public void testS3Persister() throws Exception {
+        Upload upload = mock(Upload.class);
+        when(upload.waitForUploadResult()).thenReturn(new UploadResult());
+        TransferManager transferManager = mock(TransferManager.class);
+        when(transferManager.upload(anyString(), anyString(), any())).thenReturn(upload);
+
+        S3Persister s3Persister = new S3Persister(transferManager, "foo");
+        s3Persister.saveMetrics("foo", "bar");
+
+        verify(transferManager, times(1)).upload(anyString(), anyString(), any());
+        verify(transferManager, times(1)).shutdownNow();
+        verifyNoMoreInteractions(transferManager);
+        verify(upload, times(1)).waitForCompletion();
+        verifyNoMoreInteractions(upload);
+        assertFalse(new File("foo").exists());
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testPersistApplicationDataException() throws Exception {
+        TransferManager transferManager = mock(TransferManager.class);
+        when(transferManager.upload(anyString(), anyString(), any()))
+                .thenThrow(new AmazonServiceException(""));
+
+        S3Persister s3Persister = new S3Persister(transferManager, "foo");
+
+        try {
+            s3Persister.saveMetrics("foo", "bar");
+        } finally {
+            assertFalse(new File("foo").exists());
+        }
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testPersistApplicationNullException() throws Exception {
+        Upload upload = mock(Upload.class);
+        when(upload.waitForUploadResult()).thenReturn(new UploadResult());
+        TransferManager transferManager = mock(TransferManager.class);
+        when(transferManager.upload(anyString(), anyString(), any())).thenReturn(upload);
+
+        S3Persister s3Persister = new S3Persister(transferManager, "foo");
+
+        try {
+            s3Persister.saveMetrics("foo", null);
+        } finally {
+            assertFalse(new File("foo").exists());
+        }
+    }
+}

--- a/src/test/java/com/aws/emr/profiler/core/requestprocessor/HTTPRequestProcessorTest.java
+++ b/src/test/java/com/aws/emr/profiler/core/requestprocessor/HTTPRequestProcessorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ *
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file.
+ * This file is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aws.emr.profiler.core.requestprocessor;
+
+
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.AssertJUnit.assertEquals;
+
+public class HTTPRequestProcessorTest {
+    private MockWebServer mockWebServer;
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        mockWebServer = new MockWebServer();
+        mockWebServer.start(8089);
+    }
+
+    @AfterMethod
+    public void shutdown() throws Exception {
+        mockWebServer.shutdown();
+    }
+
+    @Test
+    public void testGetResponseBodyValid() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setBody("localhost"));
+        HTTPRequestProcessor httpRequestProcessor = new HTTPRequestProcessor(mockWebServer.getHostName() + ":" +
+                String.valueOf(mockWebServer.getPort()));
+        String response = httpRequestProcessor.makeHttpGetRequest(mockWebServer.url("/foo").toString());
+        assertEquals(response, "localhost");
+        RecordedRequest recordedRequest = mockWebServer.takeRequest();
+        assertEquals(recordedRequest.getPath(), "/foo");
+        assertEquals(mockWebServer.getRequestCount(), 1);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testMakeHttpGetRequestIOException() throws Exception {
+        mockWebServer.enqueue(new MockResponse().setBody("test"));
+        OkHttpClient httpClient = mock(OkHttpClient.class, Mockito.RETURNS_DEEP_STUBS);
+        when(httpClient.newCall(any()).execute()).thenThrow(new IOException());
+        HTTPRequestProcessor httpRequestProcessor = new HTTPRequestProcessor(httpClient);
+        httpRequestProcessor.makeHttpGetRequest(mockWebServer.url("/biz").toString());
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/emr-workload-profiler/issues/2
https://github.com/awslabs/emr-workload-profiler/issues/8

*Description of changes:*

Collects Spark application metrics and save them in json in text files in S3. 

Example data: 

[ {
  "id" : "application_1513902991647_0002",
  "name" : "Spark shell",
  "attempts" : [ {
    "startTime" : "2017-12-22T21:51:52.535GMT",
    "endTime" : "2017-12-22T21:52:37.416GMT",
    "lastUpdated" : "2017-12-22T21:52:37.451GMT",
    "duration" : 44881,
    "sparkUser" : "hadoop",
    "completed" : true,
    "endTimeEpoch" : 1513979557416,
    "lastUpdatedEpoch" : 1513979557451,
    "startTimeEpoch" : 1513979512535
  } ]
}, {
  "id" : "application_1513902991647_0001",
  "name" : "Spark shell",
  "attempts" : [ {
    "startTime" : "2017-12-22T21:50:18.436GMT",
    "endTime" : "2017-12-22T21:51:06.417GMT",
    "lastUpdated" : "2017-12-22T21:51:06.459GMT",
    "duration" : 47981,
    "sparkUser" : "hadoop",
    "completed" : true,
    "endTimeEpoch" : 1513979466417,
    "lastUpdatedEpoch" : 1513979466459,
    "startTimeEpoch" : 1513979418436
  } ]
} ]


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
